### PR TITLE
Decouple video playback from explicit type references

### DIFF
--- a/Session/Modules/Tease/NoChastity/EnduranceStrokes.js
+++ b/Session/Modules/Tease/NoChastity/EnduranceStrokes.js
@@ -85,8 +85,7 @@ if (!CBT_LIMIT.isAllowed()) {
                     currentAttempts = getVar(VARIABLE.ENDURANCE_STROKES_ATTEMPTS);
 
                     if(video) {
-                        const player = Java.type('me.goddragon.teaseai.api.media.MediaHandler').getHandler().getCurrentVideoPlayer();
-                        player.stop();
+                        stopVideo();
                         unlockImages();
                     }
 
@@ -175,8 +174,7 @@ if (!CBT_LIMIT.isAllowed()) {
             }
 
             if(video) {
-                const player = Java.type('me.goddragon.teaseai.api.media.MediaHandler').getHandler().getCurrentVideoPlayer();
-                player.stop();
+                stopVideo();
                 unlockImages();
 
                 //Reset

--- a/Utils/MediaUtils.js
+++ b/Utils/MediaUtils.js
@@ -1,29 +1,30 @@
 function watchVideoForDuration(durationSeconds) {
-    const player = Java.type('me.goddragon.teaseai.api.media.MediaHandler').getHandler().getCurrentVideoPlayer();
+    sendDebugMessage('Waiting for video player to start');
 
-    if(player == null) {
-        return;
+    // We need to wait for the player to ready up and start playing before continuing
+    let totalMillisecondsWaitedForVideoToStart = 0
+    const maxMillisecondsToWaitForVideoToStart = 2000
+
+    while (!isPlayingVideo()) {
+        if (totalMillisecondsWaitedForVideoToStart >= maxMillisecondsToWaitForVideoToStart) {
+            sendDebugMessage('Video failed to start within ' + maxMillisecondsToWaitForVideoToStart + 'ms, aborting');
+            return;
+        }
+        wait(100, 'MILLISECONDS');
+        totalMillisecondsWaitedForVideoToStart += 100
     }
 
-    sendDebugMessage('Waiting for media player to start');
+    sendDebugMessage('Playing video for ' + durationSeconds + ' seconds');
 
-    //We need to wait for the player to ready up and start playing before continuing
-    while (!player.getStatus().equals(javafx.scene.media.MediaPlayer.Status.PLAYING)) {
+    const startTimeInMillis = setDate().getTimeInMillis();
+    const endTimeInMillis =  startTimeInMillis + (durationSeconds * 1000);
+
+    // Wait for specified duration or video to finish
+    while (isPlayingVideo() && (setDate().getTimeInMillis() < endTimeInMillis)) {
         wait(100, 'MILLISECONDS');
     }
-    sendDebugMessage('Currently playing ' + player.getMedia().getSource());
-    sendDebugMessage('Waiting for ' + durationSeconds);
 
-    let startDate = setDate().getTimeInMillis();
-    //Max duration in second for the video to play
-    let maxSecondsToWatch = durationSeconds;
-
-    while (player.getStatus().equals(javafx.scene.media.MediaPlayer.Status.PLAYING) && (setDate().getTimeInMillis() - startDate) < maxSecondsToWatch * 1000) {
-        //We are waiting for it to finish in intervals fo 1/10 of a second
-        wait(100, 'MILLISECONDS');
-    }
-
-    player.stop();
+    stopVideo();
     unlockImages();
 }
 


### PR DESCRIPTION
Associated code now uses the API methods that provide isolation from the
internal specifics of the MediaPlayer.

watchVideoForDuration() aborts after two seconds if the video doesn't start
playing which is a compromise to returning immediately, but that's an
exceptional case.

EnduranceStrokes is now protected from trying to stop video on a
potentially null video player.

Tested with the following script:

"
run("../Spicy/Utils/MediaUtils.js");
run("../Spicy/Chat/ChatUtil.js");

const testVideo = "Videos/Spicy/Modules/Cuckold/6.mp4"

// When nothing is playing,
//   After two seconds,
//     Should log message
//     Should return
sendMessage("Starting first playback", 0, false);
watchVideoForDuration(30);
sendMessage("Finished first playback", 0, false);
sleep(10);

// When video is longer than required duration,
//   After specified duration,
//     Should stop video
//     Should return
sendMessage("Starting second playback", 0, false);
playVideo(testVideo);
watchVideoForDuration(30);
sendMessage("Finished second playback", 0, false);
sleep(10);

// When video is shorter than required duration,
//   After video finishes,
//     Should return
sendMessage("Starting third playback", 0, false);
playVideo(testVideo);
watchVideoForDuration(180);
sendMessage("Finished third playback", 0, false);
sleep(10);

sendMessage("Done.", 0, false);
"