### PR TITLE
Fix crash when trying to edit list of butt plugs

### DIFF
--- a/Utils/GUIUtils.js
+++ b/Utils/GUIUtils.js
@@ -154,7 +154,7 @@ function createImageView() {
             let file = TAJFileUtils.getRandomMatchingFile(pathToImage);
 
             if(file !== null) {
-                let image = new javafx.scene.image.Image(file.getPath().toString());
+                let image = new javafx.scene.image.Image("file:" + file.getPath());
                 this.imageView.setImage(image);
             }
         },


### PR DESCRIPTION
When selecting a butt plug to edit, there is an attempt to show the image
of the plug selected.  As it's a local file, the file path needs to be
prefixed by "file:".