### PR TITLE
Fix ignored 'edge' responses after running endurance strokes module

### DIFF
--- a/Session/Modules/Tease/NoChastity/EnduranceStrokes.js
+++ b/Session/Modules/Tease/NoChastity/EnduranceStrokes.js
@@ -258,6 +258,7 @@ if (!CBT_LIMIT.isAllowed()) {
             addStrokingBPM(30);
         }
 
+        setTempVar(VARIABLE.ENDURANCE_STROKES_ACTIVE, false);
         //@MetronomeOn(#Var[EnduranceStrokeSpeed]) @Wait(#Random(10, 30)) @Goto(Endurance Strokes Loop) @EdgeMode(Goto, Endurance Fail Ruin)
     }
 }


### PR DESCRIPTION
The ENDURANCE_STROKES_ACTIVE flag is cleared so that the edgeResponse()
callback in 'Personalities/Spicy/Responses/Edge.js' handles the response
normally.