### PR TITLE
Fix text of "[Vivienne]" appearing very large in chat

### DIFF
--- a/Chat/ChatUtil.js
+++ b/Chat/ChatUtil.js
@@ -120,7 +120,7 @@ function sendPinnoteMessage(message, wait, skipImage) {
 }
 
 function sendVirtualAssistantMessage(message, wait, skipImage) {
-    let textName = "<c=royalblue><weight=BOLD><fs=" + TeaseAI.application.CHAT_TEXT_SIZE.getDouble() + 1 + ">[Vivienne]: ";
+    let textName = "<c=royalblue><weight=BOLD><fs=" + (TeaseAI.application.CHAT_TEXT_SIZE.getDouble() + 1) + ">[Vivienne]: ";
 
     message = replaceVocab(message);
     message = textName + "<c=royalblue><weight=MEDIUM><fs="  + TeaseAI.application.CHAT_TEXT_SIZE.getDouble() + ">" + message;


### PR DESCRIPTION
The '+ 1' was appended as a string, hence a chat size of 12 became 121
rather than the intended 13.