### PR TITLE
Fix a couple of bugs when running on Linux

### DIFF
--- a/Stroking/Taunt/StrokeAndTeaseTaunts.js
+++ b/Stroking/Taunt/StrokeAndTeaseTaunts.js
@@ -140,7 +140,7 @@ function createTauntCategory(id, name, paths) {
         let path = paths[x];
 
         //Add path seperators
-        replaceAll(path, '/', PATH_SEPARATOR);
+        path = path.replaceAll(/\//g, PATH_SEPARATOR);
 
         fileCount[x] = getScriptFilesInFolder(path).length;
         overallFileCount += fileCount[x];
@@ -186,7 +186,7 @@ function getTauntCategoryByFilePath(path) {
         for (let y = 0; y < tauntCategory.paths.length; y++) {
             let categoryPath = tauntCategory.paths[y];
 
-            categoryPath = replaceAll(categoryPath, '/', PATH_SEPARATOR);
+            categoryPath = categoryPath.replaceAll(/\//, PATH_SEPARATOR);
 
             //Cut off \*.js at the end
             categoryPath = categoryPath.substr(0, categoryPath.length - 5);

--- a/Stroking/Taunt/StrokeAndTeaseTaunts.js
+++ b/Stroking/Taunt/StrokeAndTeaseTaunts.js
@@ -140,7 +140,7 @@ function createTauntCategory(id, name, paths) {
         let path = paths[x];
 
         //Add path seperators
-        path = path.replaceAll(/\//g, PATH_SEPARATOR);
+        path = path.replace(/\//g, PATH_SEPARATOR);
 
         fileCount[x] = getScriptFilesInFolder(path).length;
         overallFileCount += fileCount[x];
@@ -186,7 +186,7 @@ function getTauntCategoryByFilePath(path) {
         for (let y = 0; y < tauntCategory.paths.length; y++) {
             let categoryPath = tauntCategory.paths[y];
 
-            categoryPath = categoryPath.replaceAll(/\//, PATH_SEPARATOR);
+            categoryPath = categoryPath.replace(/\//g, PATH_SEPARATOR);
 
             //Cut off \*.js at the end
             categoryPath = categoryPath.substr(0, categoryPath.length - 5);

--- a/Utils/FileUtils.js
+++ b/Utils/FileUtils.js
@@ -55,7 +55,7 @@ function getFilesInFolderFile(folder, recursion = false) {
         allFiles.push(files[x]);
     }
 
-    return allFiles;
+    return allFiles.sort();
 }
 
 function getScriptFilesInFolder(folder, recursion = false) {

--- a/Utils/StringUtils.js
+++ b/Utils/StringUtils.js
@@ -32,14 +32,6 @@ function deserializeObject(object, string) {
     return object;
 }
 
-function replaceAll(s, target, replace) {
-    while(s.indexOf(target) !== -1) {
-        s = s.replace(target, replace);
-    }
-
-    return s;
-}
-
 function serializeObject(object) {
     let string = '';
     for (let property in object) {


### PR DESCRIPTION
This PR fixes a couple of issues when running on Linux.

* The code goes into a loop -- the replaceAll function doesn't work if the `from` and `to` strings are the same. Just use the string method replaceAll instead
* The files in a directory are returned in a random order by default, and this causes problems when loading all the JS files. Just sort the files so that the order is the same between operating systems.